### PR TITLE
Fix zipapp build of local version on mac

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = pre_commit
-version = 2.20.0
+version = 2.20.0.post1.dev1
 description = A framework for managing and maintaining multi-language pre-commit hooks.
 long_description = file: README.md
 long_description_content_type = text/markdown

--- a/testing/zipapp/make
+++ b/testing/zipapp/make
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import argparse
 import base64
+import configparser
 import hashlib
 import importlib.resources
 import io
@@ -60,7 +61,7 @@ def _write_cache_key(version: str, wheeldir: str, dest: str) -> None:
 
 def main() -> int:
     parser = argparse.ArgumentParser()
-    parser.add_argument('version')
+    parser.add_argument('--version', required=False)
     args = parser.parse_args()
 
     with tempfile.TemporaryDirectory() as tmpdir:
@@ -70,10 +71,25 @@ def main() -> int:
         _msg('building podman image...')
         _exit_if_retv('podman', 'build', '-q', '-t', IMG, HERE)
 
+        if args.version:
+            wheel_spec = f'pre_commit=={args.version}'
+            volume_options_for_current_dir = ()
+            version = args.version
+        else:
+            wheel_spec = 'pre_commit'
+            cwd = os.getcwd()
+            volume_options_for_current_dir = (  # type: ignore
+                '--volume', f'{cwd}:{cwd}:ro',
+            )
+            config = configparser.ConfigParser()
+            config.read(f'{cwd}/setup.cfg')
+            version = config['metadata']['version']
+
         _msg('populating wheels...')
         _exit_if_retv(
-            'podman', 'run', '--rm', '--volume', f'{wheeldir}:/wheels:rw', IMG,
-            'pip', 'wheel', f'pre_commit=={args.version}', 'setuptools',
+            'podman', 'run', '--rm', '--volume', f'{wheeldir}:/wheels:rw',
+            *volume_options_for_current_dir, IMG,
+            'pip', 'wheel', wheel_spec, 'setuptools',
             '--wheel-dir', '/wheels',
         )
 
@@ -94,9 +110,9 @@ def main() -> int:
         shutil.copy(file_lock_py, file_lock_py_dest)
 
         _msg('writing CACHE_KEY...')
-        _write_cache_key(args.version, wheeldir, tmpdir)
+        _write_cache_key(version, wheeldir, tmpdir)
 
-        filename = f'pre-commit-{args.version}.pyz'
+        filename = f'pre-commit-{version}.pyz'
         _msg(f'writing {filename}...')
         shebang = '/usr/bin/env python3'
         zipapp.create_archive(tmpdir, filename, interpreter=shebang)


### PR DESCRIPTION
Changes:

- when version number is not provided, build a zipapp for the checked-out version according to setup.cfg
- fix errors when building under podman on mac

To build:
1. Ensure volumes are mapped to the podman VM:
```
podman machine init -v ${TMPDIR}:${TMPDIR} -v ${HOME}:${HOME}
podman machine start
```

2. Ensure dependencies are installed:
```
mamba install coreutils
pip install -r requirements-dev.txt
```

3. Build zipapp:
```
python3 testing/zipapp/make
```