### PR TITLE
Fix building local wheel instead of downloading remote

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = pre_commit
-version = 2.20.0.post1.dev1
+version = 2.20.0.post1.dev2
 description = A framework for managing and maintaining multi-language pre-commit hooks.
 long_description = file: README.md
 long_description_content_type = text/markdown

--- a/testing/zipapp/make
+++ b/testing/zipapp/make
@@ -76,10 +76,10 @@ def main() -> int:
             volume_options_for_current_dir = ()
             version = args.version
         else:
-            wheel_spec = 'pre_commit'
+            wheel_spec = '.'
             cwd = os.getcwd()
             volume_options_for_current_dir = (  # type: ignore
-                '--volume', f'{cwd}:{cwd}:ro',
+                '--volume', f'{cwd}:{cwd}:rw',
             )
             config = configparser.ConfigParser()
             config.read(f'{cwd}/setup.cfg')
@@ -88,6 +88,7 @@ def main() -> int:
         _msg('populating wheels...')
         _exit_if_retv(
             'podman', 'run', '--rm', '--volume', f'{wheeldir}:/wheels:rw',
+            f'--workdir={cwd}',
             *volume_options_for_current_dir, IMG,
             'pip', 'wheel', wheel_spec, 'setuptools',
             '--wheel-dir', '/wheels',


### PR DESCRIPTION
Before, we still downloaded a wheel instead of building one from local files.
```
python3 testing/zipapp/make
```
```
[...]
populating wheels...
Collecting pre_commit
  Downloading pre_commit-2.20.0-py2.py3-none-any.whl (199 kB)
[...]
```

After this PR, the wheel is built from local files:
```
python3 testing/zipapp/make
```
```
Building wheels for collected packages: pre-commit, pyyaml
  Building wheel for pre-commit (setup.py): started
  Running command python setup.py bdist_wheel
[...]
Successfully built pre-commit pyyaml
```