### PR TITLE
Fix crash on parsing valid python versions

### DIFF
--- a/pre_commit/clientlib.py
+++ b/pre_commit/clientlib.py
@@ -6,6 +6,7 @@ import logging
 import re
 import shlex
 import sys
+from pkg_resources import packaging
 from typing import Any
 from typing import Sequence
 
@@ -19,7 +20,6 @@ from pre_commit.commands.validate_manifest import validate_manifest
 from pre_commit.errors import FatalError
 from pre_commit.languages.all import all_languages
 from pre_commit.logging_handler import logging_handler
-from pkg_resources import packaging
 from pre_commit.util import yaml_load
 
 logger = logging.getLogger('pre_commit')

--- a/pre_commit/clientlib.py
+++ b/pre_commit/clientlib.py
@@ -19,7 +19,7 @@ from pre_commit.commands.validate_manifest import validate_manifest
 from pre_commit.errors import FatalError
 from pre_commit.languages.all import all_languages
 from pre_commit.logging_handler import logging_handler
-from pre_commit.util import parse_version
+from pkg_resources import packaging
 from pre_commit.util import yaml_load
 
 logger = logging.getLogger('pre_commit')
@@ -36,7 +36,7 @@ def check_type_tag(tag: str) -> None:
 
 
 def check_min_version(version: str) -> None:
-    if parse_version(version) > parse_version(C.VERSION):
+    if packaging.parse.version(version) > packaging.parse.version(C.VERSION):
         raise cfgv.ValidationError(
             f'pre-commit version {version} is required but version '
             f'{C.VERSION} is installed.  '

--- a/pre_commit/repository.py
+++ b/pre_commit/repository.py
@@ -15,7 +15,7 @@ from pre_commit.languages.all import languages
 from pre_commit.languages.helpers import environment_dir
 from pre_commit.prefix import Prefix
 from pre_commit.store import Store
-from pre_commit.util import parse_version
+from pkg_resources import packaging
 from pre_commit.util import rmtree
 
 
@@ -100,7 +100,7 @@ def _hook(
         ret.update(dct)
 
     version = ret['minimum_pre_commit_version']
-    if parse_version(version) > parse_version(C.VERSION):
+    if packaging.parse.version(version) > packaging.parse.version(C.VERSION):
         logger.error(
             f'The hook `{ret["id"]}` requires pre-commit version {version} '
             f'but version {C.VERSION} is installed.  '

--- a/pre_commit/repository.py
+++ b/pre_commit/repository.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 import logging
 import os
+from pkg_resources import packaging
 from typing import Any
 from typing import Sequence
 
@@ -15,7 +16,6 @@ from pre_commit.languages.all import languages
 from pre_commit.languages.helpers import environment_dir
 from pre_commit.prefix import Prefix
 from pre_commit.store import Store
-from pkg_resources import packaging
 from pre_commit.util import rmtree
 
 

--- a/pre_commit/util.py
+++ b/pre_commit/util.py
@@ -257,10 +257,5 @@ def rmtree(path: str) -> None:
     shutil.rmtree(path, ignore_errors=False, onerror=handle_remove_readonly)
 
 
-def parse_version(s: str) -> tuple[int, ...]:
-    """poor man's version comparison"""
-    return tuple(int(p) for p in s.split('.'))
-
-
 def win_exe(s: str) -> str:
     return s if sys.platform != 'win32' else f'{s}.exe'

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = pre_commit
-version = 2.20.0.post1.dev2
+version = 2.20.0.post1.dev3
 description = A framework for managing and maintaining multi-language pre-commit hooks.
 long_description = file: README.md
 long_description_content_type = text/markdown

--- a/tests/util_test.py
+++ b/tests/util_test.py
@@ -12,7 +12,7 @@ from pre_commit.util import cmd_output
 from pre_commit.util import cmd_output_b
 from pre_commit.util import cmd_output_p
 from pre_commit.util import make_executable
-from pre_commit.util import parse_version
+from pkg_resources import packaging
 from pre_commit.util import rmtree
 from pre_commit.util import tmpdir
 
@@ -105,12 +105,6 @@ def test_cmd_output_no_shebang(tmpdir, fn):
     assert ret == 1
     assert isinstance(out, bytes)
     assert out.endswith(b'\n')
-
-
-def test_parse_version():
-    assert parse_version('0.0') == parse_version('0.0')
-    assert parse_version('0.1') > parse_version('0.0')
-    assert parse_version('2.1') >= parse_version('2')
 
 
 def test_rmtree_read_only_directories(tmpdir):

--- a/tests/util_test.py
+++ b/tests/util_test.py
@@ -12,7 +12,6 @@ from pre_commit.util import cmd_output
 from pre_commit.util import cmd_output_b
 from pre_commit.util import cmd_output_p
 from pre_commit.util import make_executable
-from pkg_resources import packaging
 from pre_commit.util import rmtree
 from pre_commit.util import tmpdir
 


### PR DESCRIPTION
Before, the pre-commit hook failed with:
```
$ git commit -m [...]
[INFO] Initializing environment for https://github.com/pre-commit/pre-commit-hooks.
An unexpected error has occurred: ValueError: invalid literal for int() with base 10: 'post1'
Check the log at /Users/shahin/.cache/pre-commit/pre-commit.log
```

And the log showed:
```
  File "/[...]/.cache/pre-commit-zipapp/[...]/pre_commit-2.20.0.post1.dev2-py2.py3-none-any.whl/pre_commit/util.py", line 262, in <genexpr>
    return tuple(int(p) for p in s.split('.'))
ValueError: invalid literal for int() with base 10: 'post1'
```

Use standard python version parsing to fix this error caused by custom logic.