### PR TITLE
Fix crash on typo

### DIFF
--- a/pre_commit/clientlib.py
+++ b/pre_commit/clientlib.py
@@ -36,7 +36,7 @@ def check_type_tag(tag: str) -> None:
 
 
 def check_min_version(version: str) -> None:
-    if packaging.parse.version(version) > packaging.parse.version(C.VERSION):
+    if packaging.version.parse(version) > packaging.version.parse(C.VERSION):
         raise cfgv.ValidationError(
             f'pre-commit version {version} is required but version '
             f'{C.VERSION} is installed.  '

--- a/pre_commit/repository.py
+++ b/pre_commit/repository.py
@@ -100,7 +100,7 @@ def _hook(
         ret.update(dct)
 
     version = ret['minimum_pre_commit_version']
-    if packaging.parse.version(version) > packaging.parse.version(C.VERSION):
+    if packaging.version.parse(version) > packaging.version.parse(C.VERSION):
         logger.error(
             f'The hook `{ret["id"]}` requires pre-commit version {version} '
             f'but version {C.VERSION} is installed.  '


### PR DESCRIPTION
Fix crash on pre-commit due to typo in #4 :
```
$ git commit -m [...]
[INFO] Initializing environment for https://github.com/pre-commit/pre-commit-hooks.
An unexpected error has occurred: AttributeError: module 'pkg_resources._vendor.packaging' has no attribute 'parse'
Check the log at /Users/shahin/.cache/pre-commit/pre-commit.log
```